### PR TITLE
install k8s tooling on buildkite agents

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/aws.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/aws.tf
@@ -81,3 +81,11 @@ data "aws_secretsmanager_secret" "buildkite_docker_token_metadata" {
 data "aws_secretsmanager_secret_version" "buildkite_docker_token" {
   secret_id = "${data.aws_secretsmanager_secret.buildkite_docker_token_metadata.id}"
 }
+
+data "aws_secretsmanager_secret" "buildkite_api_token_metadata" {
+  name = "buildkite/agent/api-token"
+}
+
+data "aws_secretsmanager_secret_version" "buildkite_api_token" {
+  secret_id = "${data.aws_secretsmanager_secret.buildkite_api_token_metadata.id}"
+}

--- a/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
@@ -7,6 +7,7 @@ locals {
 
   buildkite_roles = [
     "roles/container.developer",
+    "roles/container.viewer",
     "roles/compute.viewer",
     "roles/stackdriver.accounts.viewer",
     "roles/pubsub.editor",

--- a/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
@@ -1,6 +1,10 @@
 locals {
   gke_project = "o1labs-192920"
-  gcs_artifact_bucket = "buildkite_k8s"
+  gcs_artifact_buckets = [
+    "buildkite_k8s",
+    "coda-charts"
+  ]
+
   buildkite_roles = [
     "roles/container.developer",
     "roles/compute.viewer",
@@ -27,15 +31,15 @@ resource "google_project_iam_member" "buildkite_iam_memberships" {
   member       = "serviceAccount:${google_service_account.gcp_buildkite_account[0].email}"
 }
 
-# Specifically bind IAM to designated bucket resource to limit access vulnerability
+# Grant storage object viewer (read) access to artifacts for all users
 resource "google_storage_bucket_iam_binding" "buildkite_gcs_binding" {
-  count = var.enable_gcs_access ? 1 : 0
+  count = var.enable_gcs_access ? length(local.gcs_artifact_buckets) : 0
 
-  bucket =local.gcs_artifact_bucket
-  role = "roles/storage.objectAdmin"
+  bucket =local.gcs_artifact_buckets[count.index]
+  role = "roles/storage.objectViewer"
 
   members = [
-    "serviceAccount:${google_service_account.gcp_buildkite_account[0].email}",
+    "allUsers"
   ]
 }
 

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -137,7 +137,7 @@ locals {
           apt-get -y update && apt install -y wget python && wget $${GSUTIL_DOWNLOAD_URL}
 
           tar -zxf $(basename $${GSUTIL_DOWNLOAD_URL}) -C /usr/local/
-          ln -s /usr/local/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
+          ln --symbolic --force /usr/local/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
 
           echo "$${BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON}" > /tmp/gcp_creds.json
 

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -98,6 +98,29 @@ locals {
       "prometheus.io/path" = "/metrics"
     }
 
+    rbac = {
+      create = true
+      role = {
+        rules = [
+          {
+            apiGroups = [
+              "",
+              "apps",
+              "batch"
+            ],
+            resources = [
+              "*"
+            ],
+            verbs = [
+              "get",
+              "list",
+              "watch"
+            ]
+          }
+        ]
+      }
+    }
+
     entrypointd = {
       "01-install-gsutil" = <<-EOF
         #!/bin/bash

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -133,6 +133,7 @@ locals {
           apt-get -y update && apt install -y wget python && wget $${GSUTIL_DOWNLOAD_URL}
 
           tar -zxf $(basename $${GSUTIL_DOWNLOAD_URL}) -C /usr/local/
+          ln -s /usr/local/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
 
           echo "$${BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON}" > /tmp/gcp_creds.json
 
@@ -183,13 +184,13 @@ locals {
         echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
         apt-get update -y && apt-get install kubectl -y
-        ln -s $(which kubectl) "$${CI_SHARED_BIN}/kubectl"
+        ln --symbolic --force $(which kubectl) "$${CI_SHARED_BIN}/kubectl"
 
         # Install helm
         curl https://baltocdn.com/helm/signing.asc | apt-key add -
         echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
         apt-get update -y && apt-get install helm -y --allow-unauthenticated
-        ln -s $(which helm) "$${CI_SHARED_BIN}/helm"
+        ln --symbolic --force $(which helm) "$${CI_SHARED_BIN}/helm"
       EOF
     }
   }

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -27,6 +27,10 @@ locals {
       "name" = "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
       "value" = var.artifact_upload_path
     },
+    {
+      "name" = "BUILDKITE_API_TOKEN"
+      "value" = data.aws_secretsmanager_secret_version.buildkite_api_token.secret_string
+    },
     # Summon EnvVars
     {
       "name" = "SUMMON_DOWNLOAD_URL"

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -182,7 +182,7 @@ locals {
         mkdir -p "$${CI_SHARED_BIN}"
 
         # Install kubectl
-        apt-get update && apt-get install --yes lsb-core apt-transport-https
+        apt-get update --yes && apt-get install --yes lsb-core apt-transport-https curl jq
 
         export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
         echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list

--- a/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -71,7 +71,7 @@ variable "artifact_upload_path" {
   type = string
 
   description = "Path to upload agent job artifacts"
-  default     = "gs://buildkite_k8s/coda/shared"
+  default     = "gs://buildkite_k8s/coda/shared/$BUILDKITE_JOB_ID"
 }
 
 # Module Vars: Summon secrets management

--- a/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -104,6 +104,13 @@ variable "helm_repo" {
   default     = "https://buildkite.github.io/charts/"
 }
 
+variable "coda_helm_repo" {
+  type = string
+
+  description = "Repository URL where to locate Coda developed Helm charts."
+  default     = "https://storage.googleapis.com/coda-charts/"
+}
+
 variable "agent_version" {
   type = string
 

--- a/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -108,7 +108,7 @@ variable "coda_helm_repo" {
   type = string
 
   description = "Repository URL where to locate Coda developed Helm charts."
-  default     = "https://storage.googleapis.com/coda-charts/"
+  default     = "gs://coda-charts"
 }
 
 variable "agent_version" {


### PR DESCRIPTION
- ensure existence of both `kubectl` and `helm` tools within *PATH* of agent container and */shared/* DIR within run containers
- store Coda's GCS Helm chart repo address as agent environment variable
- enable GCS buildkite artifact and helm chart package object view/read access for all users

[coda #5641](https://github.com/CodaProtocol/coda/issues/5641)