### PR TITLE
update buildkite agents to support GCR artifact (container image and helm chart) uploads

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
@@ -11,7 +11,8 @@ locals {
     "roles/compute.viewer",
     "roles/stackdriver.accounts.viewer",
     "roles/pubsub.editor",
-    "roles/storage.objectAdmin"
+    "roles/storage.objectAdmin",
+    "roles/storage.admin"
   ]
 }
 

--- a/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -53,10 +53,10 @@ variable "agent_config" {
   default     = {}
 }
 
-variable "gsutil_download_url" {
+variable "gcloudsdk_download_url" {
   type = string
 
-  description = "gsutil tool archive download URL"
+  description = "gcloud sdk tool archive download URL"
   default = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz"
 }
 


### PR DESCRIPTION
Also refactor gsutil download vars to more accurately represent a gcloud SDK download and install.