### PR TITLE
increase buildkite-ci agent ephemeral storage request (50g -> 100g)

### DIFF
--- a/terraform/buildkite/buildkite-ci/us-central1.tf
+++ b/terraform/buildkite/buildkite-ci/us-central1.tf
@@ -49,7 +49,7 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
-          ephemeral-storage = "50Gi"
+          ephemeral-storage = "100Gi"
         }
       }
       replicaCount = 10
@@ -68,7 +68,7 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
-          ephemeral-storage = "50Gi"
+          ephemeral-storage = "100Gi"
         }
       }
       replicaCount = 6

--- a/terraform/buildkite/buildkite-ci/us-east1.tf
+++ b/terraform/buildkite/buildkite-ci/us-east1.tf
@@ -49,7 +49,7 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
-          ephemeral-storage = "50Gi"
+          ephemeral-storage = "100Gi"
         }
       }
       replicaCount = 6
@@ -68,7 +68,7 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
-          ephemeral-storage = "50Gi"
+          ephemeral-storage = "100Gi"
         }
       }
       replicaCount = 5

--- a/terraform/buildkite/buildkite-ci/us-east4.tf
+++ b/terraform/buildkite/buildkite-ci/us-east4.tf
@@ -49,7 +49,7 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
-          ephemeral-storage = "50Gi"
+          ephemeral-storage = "100Gi"
         }
       }
       replicaCount = 6
@@ -68,7 +68,7 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
-          ephemeral-storage = "50Gi"
+          ephemeral-storage = "100Gi"
         }
       }
       replicaCount = 5


### PR DESCRIPTION
The majority of agent pod failures are caused by EVICTION due to:

`Pod ephemeral local storage usage exceeds the total limit of containers 50Gi.`

This change increases *(x2)* this storage request in order to mitigate failures while storage requirements are further evaluated. **Note** - cluster per-node total storage capacity is currently *500gb*. 