### PR TITLE
Pre-push hook to partially lock-down master pushes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+init:
+	git config core.hooksPath githooks

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+  if [[ "$remote_ref" != "refs/heads/master" ]]; then
+    # Skip this hook if we are not pushing to master
+    exit 0
+  fi
+
+  if [ "$local_sha" = $z40 ]
+  then
+    echo >&2 "No deleting master"
+    exit 1
+  else
+    # if we touch something other than testnets/.*/main.tf, abort
+    if git diff --name-only $local_sha..$remote_sha | grep -v 'terraform.testnets.*main.tf' -q; then
+      echo >&2 "Don't push to master directly, you've touched too many files. Please open a branch and do a pull-request first!"
+      exit 1
+    fi
+  fi
+done
+
+echo "Only testnets/.*/main.tf was touched, allowing push to master"
+exit 0


### PR DESCRIPTION
This PR helps ensure we follow the process outlined here https://github.com/MinaProtocol/mina/issues/6352 . Nit: I used `terraform/testnets/**/main.tf` instead of `terraform/testnets/**/*` as if you are doing something strange and using another file, it's worthy of code review.

When this lands, all folks will need to run `make init` to make the hook take effect.

I've tested that:
1. Pushes to branches other than master are unaffected
2. Pushes that include a commit where touched files other than terraform/testnets/**/main.tf are included are blocked
3. Pushes that include only commits touching terraform/testnets/**/main.tf are allowed
(2) and (3) were also tested on pushes containing more than one commit at a time.