### PR TITLE
Only check for testnets/terraform/**/* not only main.tf

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -36,13 +36,13 @@ do
     echo >&2 "No deleting master"
     exit 1
   else
-    # if we touch something other than testnets/.*/main.tf, abort
-    if git diff --name-only $local_sha..$remote_sha | grep -v 'terraform.testnets.*main.tf' -q; then
+    # if we touch something other than terraform/testnets/**/*, abort
+    if git diff --name-only $local_sha..$remote_sha | grep -v 'terraform.testnets' -q; then
       echo >&2 "Don't push to master directly, you've touched too many files. Please open a branch and do a pull-request first!"
       exit 1
     fi
   fi
 done
 
-echo "Only testnets/.*/main.tf was touched, allowing push to master"
+echo "Only terraform/testnets/**/* was touched, allowing push to master"
 exit 0


### PR DESCRIPTION
There is value on not forcing code review for simply manipulating a
genesis_ledger.json or decomposing the main.tf into more than one file
within a specific testnet deploy.