### PR TITLE
default value for coda_archive_image

### DIFF
--- a/terraform/modules/kubernetes/testnet/variables.tf
+++ b/terraform/modules/kubernetes/testnet/variables.tf
@@ -17,6 +17,7 @@ variable "coda_image" {
 
 variable "coda_archive_image" {
   type    = string
+  default = ""
 }
 
 variable "coda_agent_image" {


### PR DESCRIPTION
default value for `coda_archive_image` needed for https://github.com/MinaProtocol/coda-automation/commit/7a11de220370ab45ba5f0e8e5f0381fc8165afdd to work?