### PR TITLE
copy appropriate k8s binaries to buildkite agent/dind shared DIR rather than symlink

### DIFF
--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -196,13 +196,13 @@ locals {
         echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
         apt-get update -y && apt-get install kubectl -y
-        ln --symbolic --force $(which kubectl) "$${CI_SHARED_BIN}/kubectl"
+        cp --update --verbose $(which kubectl) "$${CI_SHARED_BIN}/kubectl"
 
         # Install helm
         curl https://baltocdn.com/helm/signing.asc | apt-key add -
         echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
         apt-get update -y && apt-get install helm -y --allow-unauthenticated
-        ln --symbolic --force $(which helm) "$${CI_SHARED_BIN}/helm"
+        cp --update --verbose $(which helm) "$${CI_SHARED_BIN}/helm"
       EOF
     }
   }


### PR DESCRIPTION
Fixes existing issue where *docker run ...* containers are unable to access the `k8s` binaries at the shared DIR due to a symlinking error.