### PR TITLE
add testnet module VAR for managing deployment of archive nodes

### DIFF
--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -93,7 +93,7 @@ locals {
     }
   }
 
-  archive_node_vars = var.coda_archive_image == null ? null : {
+  archive_node_vars = {
     testnetName = var.testnet_name
     coda = {
       image         = var.coda_image
@@ -165,7 +165,7 @@ resource "helm_release" "snark_workers" {
 }
 
 resource "helm_release" "archive_node" {
-  count      = local.archive_node_vars != null ? 1 : 0
+  count      = var.deploy_archive ? 1 : 0
   
   name       = "${var.testnet_name}-archive-node"
   chart      = "../../../helm/archive-node"

--- a/terraform/modules/kubernetes/testnet/variables.tf
+++ b/terraform/modules/kubernetes/testnet/variables.tf
@@ -62,6 +62,11 @@ variable "additional_seed_peers" {
   default = []
 }
 
+variable "deploy_archive" {
+  type    = bool
+  default = true
+}
+
 # empty string means that the deployment will use compile time constants
 variable "runtime_config" {
   type    = string


### PR DESCRIPTION
Replaces existing conditional based on setting(/non-null) of archive node image.

**note:** disabling deployment of archive nodes is currently required by integration (framework) tests.