### PR TITLE
fix block-producer helm linting error

### DIFF
--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{ $config.name }}
         testnet: {{ $.Values.testnetName }}
         role: block-producer
-        class: {{ $config.class }}
+        class: {{ default "undefined" $config.class }}
         version: {{ trunc 6 (split ":" $.Values.coda.image)._1 }}
       annotations:
         prometheus.io/scrape: 'true'


### PR DESCRIPTION
Add general default for `blockProducerConfigs` class property.