### PR TITLE
fix snark-worker runtimeConfig existence check and linting error

### DIFF
--- a/helm/snark-worker/templates/genesis-configmap.yaml
+++ b/helm/snark-worker/templates/genesis-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if (ne $.Values.coda.runtimeConfig "") -}}
+{{- if $.Values.coda.runtimeConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -45,7 +45,7 @@ spec:
           "-snark-worker-fee", "$(CODA_SNARK_FEE)",
           "-work-selection", "$(WORK_SELECTION)",
           "-enable-peer-exchange", "true",
-          {{- if (ne $.Values.coda.runtimeConfig "") }}
+          {{- if $.Values.coda.runtimeConfig }}
           "-config-file", "/config/daemon.json",
           "-generate-genesis-proof", "true",
           {{- end }}
@@ -77,7 +77,7 @@ spec:
             hostPort: {{ .Values.coordinator.hostPort }}
             protocol: TCP
         imagePullPolicy: Always
-      {{- if (ne $.Values.coda.runtimeConfig "")}}
+      {{- if $.Values.coda.runtimeConfig }}
         volumeMounts:
         - name: daemon-config
           mountPath: "/config/"

--- a/helm/snark-worker/values.yaml
+++ b/helm/snark-worker/values.yaml
@@ -6,7 +6,6 @@ coda:
     delta: 3
     txpool_max_size: 3000
     genesis_state_timestamp: "2020-04-20 11:00:00-07:00"
-    runtimeConfig: ""
   image: codaprotocol/coda-daemon:0.0.12-beta-develop-589b507
   seedPeers: 
     - /ip4/35.185.66.37/tcp/10105/p2p/12D3KooWQ7Pz3SPizarzx9ZhCJ6jNmQ2iDPgHQxVzRzqYU2SgRSd


### PR DESCRIPTION
Per Helm recommendations, rather than check for the empty string for value non-existence allow the value to be interpreted as null if not defined within *values.yaml* and check for value existence or non-null in runtimeConfig conditionals.

This change also resolves a [linting issue](https://buildkite.com/o-1-labs-2/mina/builds/4737#f4fdc060-3a53-4180-b75c-605f8756771a) in which the runtimeConfig's type (potentially null) does not match the previous conditional comparison to `""`.