### PR TITLE
bump testnet helm versions

### DIFF
--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -133,7 +133,7 @@ resource "helm_release" "seed" {
   name        = "${var.testnet_name}-seed"
   repository  = local.mina_helm_repo
   chart       = "seed-node"
-  version     = "0.1.2"
+  version     = "0.1.3"
   namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.seed_vars)
@@ -149,7 +149,7 @@ resource "helm_release" "block_producers" {
   name        = "${var.testnet_name}-block-producers"
   repository  = local.mina_helm_repo
   chart       = "block-producer"
-  version     = "0.1.9"
+  version     = "0.1.10"
   namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.block_producer_vars)
@@ -164,7 +164,7 @@ resource "helm_release" "snark_workers" {
   name        = "${var.testnet_name}-snark-worker"
   repository  = local.mina_helm_repo
   chart       = "snark-worker"
-  version     = "0.1.5"
+  version     = "0.1.6"
   namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.snark_worker_vars)
@@ -179,7 +179,7 @@ resource "helm_release" "archive_node" {
   name       = "${var.testnet_name}-archive-node"
   repository = local.mina_helm_repo
   chart      = "archive-node"
-  version    = "0.1.1"
+  version    = "0.1.2"
   namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
   values     = [
     yamlencode(local.archive_node_vars)


### PR DESCRIPTION
includes:
- removal of mina daemon container `command` override 