### PR TITLE
add per-region GCP ssd + standard infra storage classes

### DIFF
--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -39,7 +39,7 @@ locals {
 
 resource "kubernetes_storage_class" "central1_ssd" {
   metadata {
-    name = "central1-ssd"
+    name = "us-central1-ssd"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = "Delete"
@@ -50,7 +50,7 @@ resource "kubernetes_storage_class" "central1_ssd" {
 
 resource "kubernetes_storage_class" "central1_standard" {
   metadata {
-    name = "central1-standard"
+    name = "us-central1-standard"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = "Delete"

--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -37,6 +37,28 @@ locals {
   }
 }
 
+resource "kubernetes_storage_class" "central1_ssd" {
+  metadata {
+    name = "central1-ssd"
+  }
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "central1_standard" {
+  metadata {
+    name = "central1-standard"
+  }
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
 resource "google_container_cluster" "coda_cluster_central1" {
   provider = google.google_central1
   name     = "coda-infra-central1"

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -35,6 +35,28 @@ provider "google" {
   region  = "us-east1"
 }
 
+resource "kubernetes_storage_class" "east1_ssd" {
+  metadata {
+    name = "east1-ssd"
+  }
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "east1_standard" {
+  metadata {
+    name = "east1-standard"
+  }
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
 resource "google_container_cluster" "coda_cluster_east" {
   provider = google.google_east
   name     = "coda-infra-east"

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -37,7 +37,7 @@ provider "google" {
 
 resource "kubernetes_storage_class" "east1_ssd" {
   metadata {
-    name = "east1-ssd"
+    name = "us-east1-ssd"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = "Delete"
@@ -48,7 +48,7 @@ resource "kubernetes_storage_class" "east1_ssd" {
 
 resource "kubernetes_storage_class" "east1_standard" {
   metadata {
-    name = "east1-standard"
+    name = "us-east1-standard"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = "Delete"

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -37,6 +37,28 @@ locals {
   }
 }
 
+resource "kubernetes_storage_class" "east4_ssd" {
+  metadata {
+    name = "east4-ssd"
+  }
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "east4_standard" {
+  metadata {
+    name = "east4-standard"
+  }
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
 resource "google_container_cluster" "coda_cluster_east4" {
   provider = google.google_east4
   name     = "coda-infra-east4"

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -39,7 +39,7 @@ locals {
 
 resource "kubernetes_storage_class" "east4_ssd" {
   metadata {
-    name = "east4-ssd"
+    name = "us-east4-ssd"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = "Delete"
@@ -50,7 +50,7 @@ resource "kubernetes_storage_class" "east4_ssd" {
 
 resource "kubernetes_storage_class" "east4_standard" {
   metadata {
-    name = "east4-standard"
+    name = "us-east4-standard"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = "Delete"


### PR DESCRIPTION
Add basic/infrastructure GCP storage classes for GCE's persistent SSD and Standard disk types to be leveraged by stateful *Kubernetes* objects. -- [Terraform Plan](https://gist.github.com/0x0I/0b1b1d29ba7d11b17aef7d875dfd9641) 