### PR TITLE
add preemptible cluster mirrors of testnet primaries

### DIFF
--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -107,19 +107,19 @@ resource "google_container_node_pool" "central1_primary_nodes" {
   }
 }
 
-resource "google_container_node_pool" "central1_experimental_nodes" {
+resource "google_container_node_pool" "central1_preemptible_nodes" {
   provider = google.google_central1
-  name       = "coda-infra-central1"
+  name       = "mina-preemptible-central1"
   location   = "us-central1"
   cluster    = google_container_cluster.coda_cluster_central1.name
-  node_count = 1
+  node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 5
+    max_node_count = 10
   }
   node_config {
-    preemptible  = false
-    machine_type = "n2d-standard-32"
+    preemptible  = true
+    machine_type = "n1-standard-16"
     disk_size_gb = 100
 
     metadata = {

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -106,6 +106,32 @@ resource "google_container_node_pool" "east_primary_nodes" {
   }
 }
 
+resource "google_container_node_pool" "east1_preemptible_nodes" {
+  provider = google.google_east
+  name       = "mina-preemptible-east1"
+  location   = "us-east1"
+  cluster    = google_container_cluster.coda_cluster_east.name
+  node_count = 4
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 15
+  }
+  node_config {
+    preemptible  = true
+    machine_type = "n1-standard-16"
+    disk_size_gb = 500
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
 ## Buildkite
 
 resource "google_container_cluster" "buildkite_infra_east1" {

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -107,6 +107,32 @@ resource "google_container_node_pool" "east4_primary_nodes" {
   }
 }
 
+resource "google_container_node_pool" "east4_preemptible_nodes" {
+  provider = google.google_east4
+  name       = "mina-preemptible-east14"
+  location   = "us-east4"
+  cluster    = google_container_cluster.coda_cluster_east4.name
+  node_count = 4
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 15
+  }
+  node_config {
+    preemptible  = true
+    machine_type = "n1-standard-16"
+    disk_size_gb = 100
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
 provider helm {
   alias = "helm_east4"
   kubernetes {

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -109,7 +109,7 @@ resource "google_container_node_pool" "east4_primary_nodes" {
 
 resource "google_container_node_pool" "east4_preemptible_nodes" {
   provider = google.google_east4
-  name       = "mina-preemptible-east14"
+  name       = "mina-preemptible-east4"
   location   = "us-east4"
   cluster    = google_container_cluster.coda_cluster_east4.name
   node_count = 4


### PR DESCRIPTION
- parity in terms of node pool capacity with primaries is set initially (due to autoscaling being enabled and discounted pricing of *preemptible* nodes) though capacity will subsequently be adjusted once *preemptible* nodes are vetted against testnet deployments in practice
- pod *node selection/affinity* is based on the `cloud.google.com/gke-preemptible` label, set automatically on all *GKE preemptible* nodes ([example](https://console.cloud.google.com/kubernetes/node/us-east1/buildkite-infra-east1/gke-buildkite-infra--buildkite-east1--2399be82-7tys/details?project=o1labs-192920))