### PR TITLE
apply testnet gcp/gke deployment refactorizations

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -10,6 +10,7 @@ terraform {
 }
 
 locals {
+  gcp_project = "o1labs-192920"
   num_nodes_per_zone = 1
   node_type             = "n1-standard-16"
 }

--- a/terraform/infrastructure/us-west1.tf
+++ b/terraform/infrastructure/us-west1.tf
@@ -1,7 +1,8 @@
 # Testnets
 
 locals {
-  region = "us-west1"
+  west1_region = "us-west1"
+  west1_k8s_context = "gke_o1labs-192920_us-west1_mina-integration-west1"
 
   west1_prometheus_helm_values = {
     server = {
@@ -35,20 +36,20 @@ locals {
 
 provider "google" {
   alias   = "google_west1"
-  project = "o1labs-192920"
-  region  = local.region
+  project = local.gcp_project
+  region  = local.west1_region
 }
 
 data "google_compute_zones" "west1_available" {
-  project = "o1labs-192920"
-  region = local.region
+  project = local.gcp_project
+  region = local.west1_region
   status = "UP"
 }
 
 resource "google_container_cluster" "mina_integration_west1" {
   provider = google.google_west1
   name     = "mina-integration-west1"
-  location = local.region
+  location = local.west1_region
   min_master_version = "1.16"
 
   node_locations = data.google_compute_zones.west1_available.names
@@ -72,7 +73,7 @@ resource "google_container_cluster" "mina_integration_west1" {
 resource "google_container_node_pool" "west1_integration_primary" {
   provider = google.google_west1
   name       = "mina-integration-primary"
-  location   = local.region
+  location   = local.west1_region
   cluster    = google_container_cluster.mina_integration_west1.name
   node_count = 2
   autoscaling {
@@ -98,12 +99,7 @@ resource "google_container_node_pool" "west1_integration_primary" {
 provider helm {
   alias = "helm_west1"
   kubernetes {
-    host                   = "https://${google_container_cluster.mina_integration_west1.endpoint}"
-    client_certificate     = base64decode(google_container_cluster.mina_integration_west1.master_auth[0].client_certificate)
-    client_key             = base64decode(google_container_cluster.mina_integration_west1.master_auth[0].client_key)
-    cluster_ca_certificate = base64decode(google_container_cluster.mina_integration_west1.master_auth[0].cluster_ca_certificate)
-    token                  = data.google_client_config.current.access_token
-    load_config_file       = false
+    config_context = local.west1_k8s_context
   }
 }
 

--- a/terraform/modules/google-cloud/coda-seed-node/README.md
+++ b/terraform/modules/google-cloud/coda-seed-node/README.md
@@ -15,7 +15,6 @@ A terraform module to launch a Seed Node on Google Compute Engine
 | cos\_image\_name | The forced COS image to use instead of latest | `string` | `"cos-stable-77-12371-89-0"` | no |
 | discovery\_keypair | The LibP2P Keypair to use when launching the seed node. | `any` | n/a | yes |
 | instance\_name | The desired name to assign to the deployed instance | `string` | `"coda-seed-node"` | no |
-| network | The name of the subnetwork to deploy addresses into | `any` | n/a | yes |
 | project\_id | The project ID to deploy resources into | `any` | n/a | yes |
 | region | The GCP region to deploy addresses into | `string` | n/a | yes |
 | seed\_peers | An Optional space-separated list of -peer <peer-string> arguments for the coda daemon | `string` | `""` | no |

--- a/terraform/modules/google-cloud/coda-seed-node/variables.tf
+++ b/terraform/modules/google-cloud/coda-seed-node/variables.tf
@@ -16,11 +16,6 @@ variable "seed_peers" {
   description = "An Optional space-separated list of -peer <peer-string> arguments for the coda daemon"
 }
 
-
-variable "network" {
-  description = "The name of the subnetwork to deploy addresses into"
-}
-
 variable "instance_name" {
   description = "The desired name to assign to the deployed instance"
   default     = "coda-seed-node"

--- a/terraform/modules/google-cloud/vpc-network/main.tf
+++ b/terraform/modules/google-cloud/vpc-network/main.tf
@@ -1,7 +1,3 @@
-locals {
-  network_region = var.network_region
-}
-
 resource "google_compute_network" "default" {
   name = var.network_name
   project = var.project_id
@@ -10,7 +6,7 @@ resource "google_compute_network" "default" {
 resource "google_compute_subnetwork" "default" {
   name          = var.subnet_name
   ip_cidr_range = var.subnet_cidr
-  region        = local.network_region
+  region        = var.network_region
   network       = google_compute_network.default.self_link
   project = var.project_id
 }

--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -1,19 +1,9 @@
 provider helm {
   debug = true
   kubernetes {
-    host                   = "https://${data.google_container_cluster.cluster.endpoint}"
-    client_certificate     = base64decode(data.google_container_cluster.cluster.master_auth[0].client_certificate)
-    client_key             = base64decode(data.google_container_cluster.cluster.master_auth[0].client_key)
-    cluster_ca_certificate = base64decode(data.google_container_cluster.cluster.master_auth[0].cluster_ca_certificate)
-    token                  = data.google_client_config.current.access_token
-    load_config_file       = false
+    config_context  = var.k8s_context
   }
 }
-
-# data "helm_repository" "coda_helm_repo" {
-#   name = "coda-helm-repo"
-#   url  = var.coda_helm_repo
-# }
 
 locals {
   mina_helm_repo = "https://coda-charts.storage.googleapis.com"

--- a/terraform/modules/kubernetes/testnet/kubernetes.tf
+++ b/terraform/modules/kubernetes/testnet/kubernetes.tf
@@ -1,19 +1,5 @@
-data "google_client_config" "current" {}
-
-data "google_container_cluster" "cluster" {
-  name     = var.cluster_name
-  location = var.cluster_region
-}
-
-
-provider "kubernetes" {
-  host                   = "https://${data.google_container_cluster.cluster.endpoint}"
-  client_certificate     = base64decode(data.google_container_cluster.cluster.master_auth[0].client_certificate)
-  client_key             = base64decode(data.google_container_cluster.cluster.master_auth[0].client_key)
-  cluster_ca_certificate = base64decode(data.google_container_cluster.cluster.master_auth[0].cluster_ca_certificate)
-  token                  = data.google_client_config.current.access_token
-  load_config_file       = false
-
+provider kubernetes {
+    config_context  = var.k8s_context
 }
 
 resource "kubernetes_namespace" "testnet_namespace" {

--- a/terraform/modules/kubernetes/testnet/variables.tf
+++ b/terraform/modules/kubernetes/testnet/variables.tf
@@ -8,6 +8,13 @@ variable "cluster_region" {
   type = string
 }
 
+variable "k8s_context" {
+  type = string
+
+  description = "K8s resource provider context"
+  default     = "gke_o1labs-192920_us-east1_coda-infra-east"
+}
+
 # Global Vars
 
 variable "coda_image" {


### PR DESCRIPTION
- *ONLY* deploy infra to UP/active region availability zones
- modify testnet module's *k8s* provider to make use of variable context (**defaults to:** `gke_o1labs-192920_us-east1_coda-infra-east` -- **coda-infra** cluster located in **us-east1** region)