### PR TITLE
fix ci k8s tool downloads and update minimum required version of terraform for buildkite cluster ops

### DIFF
--- a/terraform/buildkite/buildkite-ci/main.tf
+++ b/terraform/buildkite/buildkite-ci/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.3"
   backend "s3" {
     key     = "terraform-bk-coda-ci.tfstate"
     encrypt = true

--- a/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -115,7 +115,7 @@ variable "agent_version" {
   type = string
 
   description = "Version of Buildkite agent to launch"
-  default     = "3-ubuntu"
+  default     = "3.25.0-ubuntu"
 }
 
 variable "chart_version" {


### PR DESCRIPTION
Agent's docker image version [(3-ubuntu)](https://hub.docker.com/layers/buildkite/agent/3-ubuntu/images/sha256-d7d67200e591dbe589289c803f025083396dbb287beb0d8c4eefe8a2351b0de4?context=explore) was recently updated under the hood to latest version of Ubuntu (Focal Fossa); resulting in package download failures for `k8s` tools due to tool packages not yet included in fossa's repo. Latest version of tools are currently maintained in *xenial* and lower.