### PR TITLE
add integration test cleanup cronjob in default namespace of us-east4

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -15,4 +15,3 @@ locals {
 }
 
 data "google_client_config" "current" {}
-

--- a/terraform/infrastructure/service-accounts.tf
+++ b/terraform/infrastructure/service-accounts.tf
@@ -1,0 +1,28 @@
+locals {
+  gke_project = "o1labs-192920"
+
+  janitor_roles = [
+    "roles/container.developer",
+    "roles/container.viewer",
+    "roles/compute.viewer"
+  ]
+}
+
+resource "google_service_account" "gcp_janitor_account" {
+  account_id   = "gcp-janitor-svc"
+  display_name = "GCP Janitor Service"
+  description  = "GCP janitor service account for managing resource authorization"
+  project      = local.gke_project
+}
+
+resource "google_project_iam_member" "janitor_iam_memberships" {
+  count = length(local.janitor_roles)
+
+  project      =  local.gke_project
+  role         =  local.janitor_roles[count.index]
+  member       = "serviceAccount:${google_service_account.gcp_janitor_account[0].email}"
+}
+
+resource "google_service_account_key" "janitor_svc_key" {
+  service_account_id = google_service_account.gcp_janitor_account[0].name
+}

--- a/terraform/infrastructure/service-accounts.tf
+++ b/terraform/infrastructure/service-accounts.tf
@@ -20,9 +20,9 @@ resource "google_project_iam_member" "janitor_iam_memberships" {
 
   project      =  local.gke_project
   role         =  local.janitor_roles[count.index]
-  member       = "serviceAccount:${google_service_account.gcp_janitor_account[0].email}"
+  member       = "serviceAccount:${google_service_account.gcp_janitor_account.email}"
 }
 
 resource "google_service_account_key" "janitor_svc_key" {
-  service_account_id = google_service_account.gcp_janitor_account[0].name
+  service_account_id = google_service_account.gcp_janitor_account.name
 }

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -245,11 +245,13 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
               command = [
                 "/scripts/network-utilities.py",
                 "janitor",
-                "cleanup_namespace_resources",
+                "cleanup-namespace-resources",
                 "--namespace-pattern",
                 ".*integration.*",
                 "--k8s-context",
-                "gke_o1labs-192920_us-west1_mina-integration-west1"
+                "gke_o1labs-192920_us-west1_mina-integration-west1",
+                "--kube-config-file",
+                "/root/.kube/config"
               ]
               env {
                 name  = "GCLOUD_APPLICATION_CREDENTIALS_JSON"

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -241,11 +241,23 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
           spec {
             container {
               name    = "integration-test-janitor"
-              image   = "gcr.io/o1labs-192920/coda-network-services:latest"
-              command = ["/bin/sh", "-c", "/scripts/network-utilities.py janitor cleanup_namespace_resources"]
+              image   = "gcr.io/o1labs-192920/coda-network-services:0.3.0"
+              command = [
+                "/scripts/network-utilities.py",
+                "janitor",
+                "cleanup_namespace_resources",
+                "--namespace-pattern",
+                ".*integration.*",
+                "--k8s-context",
+                "gke_o1labs-192920_us-west1_mina-integration-west1"
+              ]
               env {
                 name  = "GCLOUD_APPLICATION_CREDENTIALS_JSON"
                 value = base64decode(google_service_account_key.janitor_svc_key.private_key)
+              }
+              env {
+                name  = "CLUSTER_SERVICE_EMAIL"
+                value = google_service_account.gcp_janitor_account.email
               }
             }
           }

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -234,7 +234,7 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
     job_template {
       metadata {}
       spec {
-        backoff_limit              = 2
+        backoff_limit              = 5
         ttl_seconds_after_finished = 10
         template {
           metadata {}
@@ -242,7 +242,7 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
             container {
               name    = "integration-test-janitor"
               image   = "gcr.io/o1labs-192920/coda-network-services:0.3.0"
-              command = [
+              args = [
                 "/scripts/network-utilities.py",
                 "janitor",
                 "cleanup-namespace-resources",

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -242,7 +242,11 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
             container {
               name    = "integration-test-janitor"
               image   = "gcr.io/o1labs-192920/coda-network-services:latest"
-              command = ["/bin/bash", "-c", "/scripts/network-utilities.py janitor cleanup_namespace_resources"]
+              command = ["/bin/sh", "-c", "/scripts/network-utilities.py janitor cleanup_namespace_resources"]
+              env {
+                name  = "GCLOUD_APPLICATION_CREDENTIALS_JSON"
+                value = base64decode(google_service_account_key.janitor_svc_key.private_key)
+              }
             }
           }
         }


### PR DESCRIPTION
- runs nightly at midnight
- currently set to scan *integration* related namespaces within the *mina-integration-west1* cluster though can be extended
- job provisioning is namespace-agnostic