### PR TITLE
convert archive postgres persistence access modes var to list

### DIFF
--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -120,7 +120,7 @@ locals {
       persistence = {
         enabled = var.archive_persistence_enabled
         storageClass = "${var.cluster_region}-${var.archive_persistence_class}"
-        accessModes = var.archive_persistence_access_mode
+        accessModes = var.archive_persistence_access_modes
         size = var.archive_persistence_size
       }
     }

--- a/terraform/modules/kubernetes/testnet/variables.tf
+++ b/terraform/modules/kubernetes/testnet/variables.tf
@@ -241,9 +241,9 @@ variable "archive_persistence_class" {
   default = "ssd"
 }
 
-variable "archive_persistence_access_mode" {
-  type    = string
-  default = "ReadWriteOnce"
+variable "archive_persistence_access_modes" {
+  type    = list
+  default = ["ReadWriteOnce"]
 }
 
 variable "archive_persistence_size" {


### PR DESCRIPTION
Fix archive-node *Terraform/Helm* deployment postgres persistence access mode var by converting to proper `list` type. Also rename to more clearly indicate multiple values are allowed.