### PR TITLE
adjust integration test cleanup cron to account for UTC timezone shift

### DIFF
--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -228,7 +228,7 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
   spec {
     concurrency_policy            = "Replace"
     failed_jobs_history_limit     = 5
-    schedule                      = "0 5 * * *"
+    schedule                      = "0 8 * * *"
     starting_deadline_seconds     = 10
     successful_jobs_history_limit = 10
     job_template {

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -228,7 +228,7 @@ resource "kubernetes_cron_job" "integration-testnet-cleanup" {
   spec {
     concurrency_policy            = "Replace"
     failed_jobs_history_limit     = 5
-    schedule                      = "0 0 * * *"
+    schedule                      = "0 5 * * *"
     starting_deadline_seconds     = 10
     successful_jobs_history_limit = 10
     job_template {


### PR DESCRIPTION
Schedule is based on UTC relative to the timezone in which the *k8s* cluster master is located. In this case, since the job has been provisioned within the **us-east4** cluster (= *Virginia/EST*), the master is on EST and thus -5 behind UTC. 

Also adjust for PST midnight execution (-8 from UTC) vs. EST midnight.