### PR TITLE
Adjust infra scale of primary/preemptible node types

### DIFF
--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -78,7 +78,7 @@ resource "google_container_node_pool" "central1_primary_nodes" {
   node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 10
+    max_node_count = 5
   }
   node_config {
     preemptible  = false
@@ -105,7 +105,7 @@ resource "google_container_node_pool" "central1_preemptible_nodes" {
   node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 10
+    max_node_count = 5
   }
   node_config {
     preemptible  = true

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -79,7 +79,7 @@ resource "google_container_node_pool" "east_primary_nodes" {
   node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 15
+    max_node_count = 7
   }
   node_config {
     preemptible  = false
@@ -105,7 +105,7 @@ resource "google_container_node_pool" "east1_preemptible_nodes" {
   node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 15
+    max_node_count = 7
   }
   node_config {
     preemptible  = true

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -79,7 +79,7 @@ resource "google_container_node_pool" "east4_primary_nodes" {
   node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 15
+    max_node_count = 7
   }
   node_config {
     preemptible  = false
@@ -105,7 +105,7 @@ resource "google_container_node_pool" "east4_preemptible_nodes" {
   node_count = 4
   autoscaling {
     min_node_count = 0
-    max_node_count = 15
+    max_node_count = 7
   }
   node_config {
     preemptible  = true


### PR DESCRIPTION
Infrastructure node scale across regions was technically doubled while preemptible node pools and provisioning logic were tested. This change restores the expected capacity of available nodes/resources per region based on the existence of both `primary/non-preemptible` and `preemptible` node types.