### PR TITLE
explicitly set providers for infra storage class resources

### DIFF
--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -38,6 +38,11 @@ provider "google" {
   region  = local.central1_region
 }
 
+provider "kubernetes" {
+  alias   = "k8s_central1"
+  config_context = local.central1_k8s_context
+}
+
 data "google_compute_zones" "central1_available" {
   project = local.gcp_project
   region = local.central1_region
@@ -177,6 +182,8 @@ resource "google_container_node_pool" "central1_compute_nodes" {
 ## Data Persistence
 
 resource "kubernetes_storage_class" "central1_ssd" {
+  provider = kubernetes.k8s_central1
+
   count = length(local.storage_reclaim_policies)
 
   metadata {
@@ -192,6 +199,8 @@ resource "kubernetes_storage_class" "central1_ssd" {
 }
 
 resource "kubernetes_storage_class" "central1_standard" {
+  provider = kubernetes.k8s_central1
+
   count = length(local.storage_reclaim_policies)
 
   metadata {

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -38,6 +38,11 @@ provider "google" {
   region  = local.east1_region
 }
 
+provider "kubernetes" {
+  alias   = "k8s_east1"
+  config_context = local.east1_k8s_context
+}
+
 data "google_compute_zones" "east1_available" {
   project = local.gcp_project
   region = local.east1_region
@@ -177,6 +182,8 @@ resource "google_container_node_pool" "east1_compute_nodes" {
 ## Data Persistence
 
 resource "kubernetes_storage_class" "east1_ssd" {
+  provider = kubernetes.k8s_east1
+
   count = length(local.storage_reclaim_policies)
 
   metadata {
@@ -191,6 +198,8 @@ resource "kubernetes_storage_class" "east1_ssd" {
 }
 
 resource "kubernetes_storage_class" "east1_standard" {
+  provider = kubernetes.k8s_east1
+
   count = length(local.storage_reclaim_policies)
 
   metadata {

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -39,6 +39,11 @@ provider "google" {
   region  = local.east4_region
 }
 
+provider "kubernetes" {
+  alias   = "k8s_east4"
+  config_context = local.east4_k8s_context
+}
+
 data "google_compute_zones" "east4_available" {
   project = "o1labs-192920"
   region = local.east4_region
@@ -177,6 +182,8 @@ resource "google_container_node_pool" "east4_compute_nodes" {
 ## Data Persistence
 
 resource "kubernetes_storage_class" "east4_ssd" {
+  provider = kubernetes.k8s_east4
+
   count = length(local.storage_reclaim_policies)
 
   metadata {
@@ -192,6 +199,8 @@ resource "kubernetes_storage_class" "east4_ssd" {
 }
 
 resource "kubernetes_storage_class" "east4_standard" {
+  provider = kubernetes.k8s_east4
+
   count = length(local.storage_reclaim_policies)
 
   metadata {

--- a/terraform/infrastructure/us-west1.tf
+++ b/terraform/infrastructure/us-west1.tf
@@ -38,6 +38,11 @@ provider "google" {
   region  = local.west1_region
 }
 
+provider "kubernetes" {
+  alias   = "k8s_west1"
+  config_context = local.west1_k8s_context
+}
+
 data "google_compute_zones" "west1_available" {
   project = local.gcp_project
   region = local.west1_region
@@ -99,6 +104,8 @@ resource "google_container_node_pool" "west1_integration_primary" {
 ## Data Persistence
 
 resource "kubernetes_storage_class" "west1_ssd" {
+  provider = kubernetes.k8s_west1
+
   count = length(local.storage_reclaim_policies)
 
   metadata {
@@ -114,6 +121,8 @@ resource "kubernetes_storage_class" "west1_ssd" {
 }
 
 resource "kubernetes_storage_class" "west1_standard" {
+  provider = kubernetes.k8s_west1
+
   count = length(local.storage_reclaim_policies)
 
   metadata {


### PR DESCRIPTION
Adding providers directly makes `terraform apply`'ing simpler and less error prone by removing the operator's current (config) environment from the equation. We may actually want to create a set of providers somewhere and directly specify a provider for each resource (where appropriate). Could get noisy and a burden to maintain though.