### PR TITLE
bump versions of testnet component Helm charts

### DIFF
--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -141,7 +141,7 @@ resource "helm_release" "seed" {
   name        = "${var.testnet_name}-seed"
   repository  = local.use_local_charts ? "" : local.mina_helm_repo
   chart       = local.use_local_charts ? "../../../helm/seed-node" : "seed-node"
-  version     = "0.1.4"
+  version     = "0.3.2"
   namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.seed_vars)
@@ -151,13 +151,13 @@ resource "helm_release" "seed" {
 }
 
 
-# Block Producers
+# Block Producer
 
 resource "helm_release" "block_producers" {
   name        = "${var.testnet_name}-block-producers"
   repository  = local.use_local_charts ? "" : local.mina_helm_repo
   chart       = local.use_local_charts ? "../../../helm/block-producer" : "block-producer"
-  version     = "0.1.11"
+  version     = "0.3.2"
   namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.block_producer_vars)
@@ -166,13 +166,13 @@ resource "helm_release" "block_producers" {
   depends_on  = [helm_release.seed]
 }
 
-# Snark Workers 
+# Snark Worker
 
 resource "helm_release" "snark_workers" {
   name        = "${var.testnet_name}-snark-worker"
   repository  = local.use_local_charts ? "" : local.mina_helm_repo
   chart       = local.use_local_charts ? "../../../helm/snark-worker" : "snark-worker"
-  version     = "0.1.7"
+  version     = "0.3.3"
   namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.snark_worker_vars)
@@ -181,13 +181,15 @@ resource "helm_release" "snark_workers" {
   depends_on  = [helm_release.seed]
 }
 
+# Archive Node
+
 resource "helm_release" "archive_node" {
   count      = var.deploy_archive ? 1 : 0
   
   name       = "${var.testnet_name}-archive-node"
   repository  = local.use_local_charts ? "" : local.mina_helm_repo
   chart       = local.use_local_charts ? "../../../helm/archive-node" : "archive-node"
-  version    = "0.1.3"
+  version    = "0.3.3"
   namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
   values     = [
     yamlencode(local.archive_node_vars)


### PR DESCRIPTION
**Changelog:**
- testnet component healthchecks (startup, liveness and readiness probes)
- testnet networking/ClusterIP setup
- *k8s* pod port refactorization
- enabling of archive-node persistence
- testnet component pod preemptible node affinity/anti-affinity
- misc. chart fixes/refactors

**Test:** Buildkite CI && observed [block-producing/healthy network](https://o1testnet.grafana.net/d/qx4y6dfWz/network-overview?orgId=1&from=1608318000000&to=1608325200000&var-testnet=ci-net)