### PR TITLE
enable deployment of multiple archive-nodes and refactor app/naming scheme

### DIFF
--- a/terraform/modules/kubernetes/testnet/helm.tf
+++ b/terraform/modules/kubernetes/testnet/helm.tf
@@ -184,16 +184,17 @@ resource "helm_release" "snark_workers" {
 # Archive Node
 
 resource "helm_release" "archive_node" {
-  count      = var.deploy_archive ? 1 : 0
+  count       = var.archive_node_count
   
-  name       = "${var.testnet_name}-archive-node"
+  name        = "archive-node-${count.index}"
   repository  = local.use_local_charts ? "" : local.mina_helm_repo
   chart       = local.use_local_charts ? "../../../helm/archive-node" : "archive-node"
-  version    = "0.3.3"
-  namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
-  values     = [
+  version     = "0.3.3"
+  namespace   = kubernetes_namespace.testnet_namespace.metadata[0].name
+  values      = [
     yamlencode(local.archive_node_vars)
   ]
+
   wait = false
   depends_on = [helm_release.seed]
 }

--- a/terraform/modules/kubernetes/testnet/variables.tf
+++ b/terraform/modules/kubernetes/testnet/variables.tf
@@ -74,9 +74,9 @@ variable "additional_seed_peers" {
   default = []
 }
 
-variable "deploy_archive" {
-  type    = bool
-  default = true
+variable "archive_node_count" {
+  type    = number
+  default = 0
 }
 
 # empty string means that the deployment will use compile time constants


### PR DESCRIPTION
Replace `deploy_archive` module variable (used to flag whether to deploy zero or a single instance of the archive-node) with `archive_node_count` in order to allow deployment of multiple archive node instances. Also refactor app naming scheme to be more dynamic and rely on the guaranteed to be unique Helm `Release.Name` chart variable.