### PR TITLE
increase mina testnet infra preemptible-node auto-scale max

### DIFF
--- a/terraform/infrastructure/us-central1.tf
+++ b/terraform/infrastructure/us-central1.tf
@@ -102,10 +102,10 @@ resource "google_container_node_pool" "central1_preemptible_nodes" {
   location   = local.central1_region
   cluster    = google_container_cluster.coda_cluster_central1.name
   
-  node_count = 4
+  node_count = 5
   autoscaling {
     min_node_count = 0
-    max_node_count = 5
+    max_node_count = 15
   }
   node_config {
     preemptible  = true

--- a/terraform/infrastructure/us-east1.tf
+++ b/terraform/infrastructure/us-east1.tf
@@ -102,10 +102,10 @@ resource "google_container_node_pool" "east1_preemptible_nodes" {
   name       = "mina-preemptible-east1"
   location   = local.east1_region
   cluster    = google_container_cluster.coda_cluster_east.name
-  node_count = 4
+  node_count = 5
   autoscaling {
     min_node_count = 0
-    max_node_count = 7
+    max_node_count = 20
   }
   node_config {
     preemptible  = true

--- a/terraform/infrastructure/us-east4.tf
+++ b/terraform/infrastructure/us-east4.tf
@@ -102,10 +102,10 @@ resource "google_container_node_pool" "east4_preemptible_nodes" {
   name       = "mina-preemptible-east4"
   location   = local.east4_region
   cluster    = google_container_cluster.coda_cluster_east4.name
-  node_count = 4
+  node_count = 5
   autoscaling {
     min_node_count = 0
-    max_node_count = 7
+    max_node_count = 20
   }
   node_config {
     preemptible  = true

--- a/terraform/infrastructure/us-west1.tf
+++ b/terraform/infrastructure/us-west1.tf
@@ -75,10 +75,10 @@ resource "google_container_node_pool" "west1_integration_primary" {
   name       = "mina-integration-primary"
   location   = local.west1_region
   cluster    = google_container_cluster.mina_integration_west1.name
-  node_count = 2
+  node_count = 5
   autoscaling {
     min_node_count = 0
-    max_node_count = 5
+    max_node_count = 20
   }
   node_config {
     preemptible  = true


### PR DESCRIPTION
Considering that most of the scale/resource usage from testnets comes from deployment of block-producers and snark-workers, both of which now have an affinity for **preemptible nodes**, increase the auto-scale max for all infrastructure preemptible node-pools to better support deployments at scale.

**Note:** autoscale max equals maximum node count per availability zone (goal is to allow a total of 60 nodes per region taking into consideration the # of AZs in that region).