### PR TITLE
explicitly add setting of kube config to load for buildkite k8s providers

### DIFF
--- a/terraform/buildkite/buildkite-ci/monitoring.tf
+++ b/terraform/buildkite/buildkite-ci/monitoring.tf
@@ -53,12 +53,16 @@ locals {
 }
 
 provider helm {
+  alias = "bk_monitoring"
   kubernetes {
+    config_path = "~/.kube/config"
     config_context  = var.k8s_monitoring_ctx
   }
 }
 
 resource "helm_release" "buildkite_graphql_exporter" {
+  provider  = helm.bk_monitoring
+
   name      = "buildkite-coda-exporter"
   chart     = "../../../helm/buildkite-exporter"
   namespace = local.project_namespace
@@ -73,6 +77,8 @@ resource "helm_release" "buildkite_graphql_exporter" {
 }
 
 resource "helm_release" "buildkite_prometheus" {
+  provider  = helm.bk_monitoring
+
   name      = "${local.project_namespace}-prometheus"
   chart     = "stable/prometheus"
   namespace = local.project_namespace

--- a/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -1,16 +1,14 @@
 provider kubernetes {
-    config_context  = var.k8s_context
+  alias = "bk_deploy"
+  config_path = "~/.kube/config"
+  config_context  = var.k8s_context
 }
 
 provider helm {
+  alias = "bk_deploy"
   kubernetes {
+    config_path = "~/.kube/config"
     config_context  = var.k8s_context
-  }
-}
-
-resource "kubernetes_namespace" "cluster_namespace" {
-  metadata {
-    name = var.cluster_name
   }
 }
 
@@ -208,8 +206,18 @@ locals {
   }
 }
 
+resource "kubernetes_namespace" "cluster_namespace" {
+  provider = kubernetes.bk_deploy
+
+  metadata {
+    name = var.cluster_name
+  }
+}
+
 resource "helm_release" "buildkite_agents" {
   for_each   = var.agent_topology
+
+  provider   = helm.bk_deploy
  
   name              = "${var.cluster_name}-buildkite-${each.key}"
   repository        = "buildkite"


### PR DESCRIPTION
Also ensure setting of dedicated *k8s* and *Helm* providers for each buildkite agent release in order to avoid dependency on operator's *k8s* config/environment.